### PR TITLE
Add missing alpine packages to Dockerfile

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -15,6 +15,7 @@ COPY open-source-tpm-alpine-spdx.rdf /
 
 RUN apk update && \
     apk add \
+    acl \
     autoconf \
     autoconf-archive \
     automake \
@@ -34,6 +35,7 @@ RUN apk update && \
     glib-dev \
     libconfig-dev \
     libgcrypt-dev \
+    shadow \
     wget
 
 RUN mkdir tpm2


### PR DESCRIPTION
I couldn't manage to build the whole docker image, but this fixes some issues building the tpm2-tools libraries.
I'm not using this Docker image directly (just the tpm tools portion), but I figured I should post my fix for others.