### PR TITLE
update ibmsim, remove tss user, add alpine version

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,5 +1,5 @@
 #TPM2 simulator with alpine base
-FROM alpine:latest
+FROM alpine:3.13.6
 LABEL Maintainer="Ronny Backman <ronny.backman@nokia.com>"
 LABEL version="1.0"
 LABEL description="Base image for running TPM2 Software Stack (TSS), Access \
@@ -67,15 +67,14 @@ RUN ./bootstrap && \
 
 
 WORKDIR /tpm2/ibmsim
-RUN wget --quiet --show-progress --progress=dot:giga --no-check-certificate "https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm1563.tar.gz"
-RUN tar -xf ibmtpm1563.tar.gz
+RUN wget --quiet --show-progress --progress=dot:giga --no-check-certificate "https://downloads.sourceforge.net/project/ibmswtpm2/ibmtpm1661.tar.gz"
+RUN tar -xf ibmtpm1661.tar.gz
 WORKDIR /tpm2/ibmsim/src
 RUN make -j4
 RUN cp tpm_server /bin/
 
 
 WORKDIR /
-RUN adduser -S -D tss
 
 COPY tpmStartup.sh /bin/
 


### PR DESCRIPTION
- Removed `tss` user addition since alpine doesn't use systemd and therefore it is added during build of tpm2-tss (https://github.com/tpm2-software/tpm2-tss/issues/1611)
- Update `ibmsim` version (encountered some gcc related error with older version)
- Fixed alpine version to `3.13.6`. `13.4.x` build fails due to `autoconf` issues.